### PR TITLE
Allow platform account to distribute AMIs

### DIFF
--- a/accounts/workflow/.terraform.lock.hcl
+++ b/accounts/workflow/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.12.0"
+  version = "5.36.0"
   hashes = [
-    "h1:GWmoet1icv68bVcTQ4EGOCUUJ5vbyhzubL8Y3c7Se+Q=",
+    "h1:54QgAU2vY65WZsiZ9FligQfIf7hQUvwse4ezMwVMwgg=",
+    "zh:0da8409db879b2c400a7d9ed1311ba6d9eb1374ea08779eaf0c5ad0af00ac558",
+    "zh:1b7521567e1602bfff029f88ccd2a182cdf97861c9671478660866472c3333fa",
+    "zh:1cab4e6f3a1d008d01df44a52132a90141389e77dbb4ec4f6ac1119333242ecf",
+    "zh:1df9f73595594ce8293fb21287bcacf5583ae82b9f3a8e5d704109b8cf691646",
+    "zh:2b5909268db44b6be95ff6f9dc80d5f87ca8f63ba530fe66723c5fdeb17695fc",
+    "zh:37dd731eeb0bc1b20e3ec3a0cb5eb7a730edab425058ff40f2243438acc82830",
+    "zh:3e94c76a2b607a1174d10f5712aed16cb32216ac1c91bd6f21749d61a14045ac",
+    "zh:40e6ba3184d2d3bf283a07feed8b79c1bbc537a91215cac7b3521b9ccb3e503e",
+    "zh:67e52353fea47eb97825f6eb6fddd1935e0ff3b53a8861d23a70c2babf83ae51",
+    "zh:6d2e2f390e0c7b2cd2344b1d5d6eec8a1c11cf35d19f1d6f341286f2449e9e10",
+    "zh:7005483c43926800fad5bb18e27be883dac4339edb83a8f18ccdc7edf86fafc2",
+    "zh:7073fa7ccaa9b07c2cf7b24550a90e11f4880afd5c53afd51278eff0154692a0",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6d48620e526c766faec9aeb20c40a98c1810c69b6699168d725f721dfe44846",
+    "zh:e29b651b5f39324656f466cd24a54861795cc423a1b58372f4e1d2d2112d10a0",
   ]
 }

--- a/modules/account_roles/image-builder/main.tf
+++ b/modules/account_roles/image-builder/main.tf
@@ -9,7 +9,7 @@ resource "aws_iam_role" "EC2ImageBuilderDistributionCrossAccountRole" {
       {
         Action = "sts:AssumeRole",
         Effect = "Allow",
-        Sid = "",
+        Sid    = "",
         Principal = {
           AWS = var.target_account_id
         }
@@ -19,7 +19,7 @@ resource "aws_iam_role" "EC2ImageBuilderDistributionCrossAccountRole" {
 }
 
 resource "aws_iam_policy_attachment" "EC2ImageBuilderDistributionCrossAccountRoleAttachment" {
-  name = "EC2ImageBuilderDistributionCrossAccountRoleAttachment"
-  roles = [aws_iam_role.EC2ImageBuilderDistributionCrossAccountRole.name]
+  name       = "EC2ImageBuilderDistributionCrossAccountRoleAttachment"
+  roles      = [aws_iam_role.EC2ImageBuilderDistributionCrossAccountRole.name]
   policy_arn = "arn:aws:iam::aws:policy/EC2ImageBuilderCrossAccountDistributionAccess"
 }

--- a/modules/account_roles/image-builder/main.tf
+++ b/modules/account_roles/image-builder/main.tf
@@ -1,0 +1,25 @@
+# This role allows AWS image builder to assume a role in the target account to distribute the image.
+
+# create an aws iam rone in terraform called EC2ImageBuilderDistributionCrossAccountRole with a trust relationship specifiying another AWS account via a varaible
+resource "aws_iam_role" "EC2ImageBuilderDistributionCrossAccountRole" {
+  name = "EC2ImageBuilderDistributionCrossAccountRole"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Sid = "",
+        Principal = {
+          AWS = var.target_account_id
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy_attachment" "EC2ImageBuilderDistributionCrossAccountRoleAttachment" {
+  name = "EC2ImageBuilderDistributionCrossAccountRoleAttachment"
+  roles = [aws_iam_role.EC2ImageBuilderDistributionCrossAccountRole.name]
+  policy_arn = "arn:aws:iam::aws:policy/EC2ImageBuilderCrossAccountDistributionAccess"
+}

--- a/modules/account_roles/image-builder/variables.tf
+++ b/modules/account_roles/image-builder/variables.tf
@@ -1,5 +1,5 @@
 variable "target_account_id" {
   description = "The account id of the target account to distribute the image to"
   type        = string
-  
+
 }

--- a/modules/account_roles/image-builder/variables.tf
+++ b/modules/account_roles/image-builder/variables.tf
@@ -1,0 +1,5 @@
+variable "target_account_id" {
+  description = "The account id of the target account to distribute the image to"
+  type        = string
+  
+}

--- a/modules/account_roles/main.tf
+++ b/modules/account_roles/main.tf
@@ -66,7 +66,7 @@ module "ci_role_policy" {
 }
 
 module "image_builder" {
-  source = "./image-builder"
+  source            = "./image-builder"
   target_account_id = var.ami_distribution_account_id
 }
 

--- a/modules/account_roles/main.tf
+++ b/modules/account_roles/main.tf
@@ -65,6 +65,10 @@ module "ci_role_policy" {
   sbt_releases_bucket_arn = var.sbt_releases_bucket_arn
 }
 
+module "image_builder" {
+  source = "./image-builder"
+  target_account_id = var.ami_distribution_account_id
+}
 
 # This defines a couple of standard roles in our account which are
 # used by the InfoSec team in D&T.

--- a/modules/account_roles/variables.tf
+++ b/modules/account_roles/variables.tf
@@ -16,3 +16,9 @@ variable "sbt_releases_bucket_arn" {
   type    = string
   default = "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org"
 }
+
+variable "ami_distribution_account_id" {
+  type = string
+  # This is the account id of the account that will receive the AMI (default is platform account id)
+  default = "760097843905"
+}


### PR DESCRIPTION
## What does this change?

This change adds a `EC2ImageBuilderDistributionCrossAccountRole` to the standard account roles attaches the managed policy `Ec2ImageBuilderCrossAccountDistributionAccess ` and adds a trust relationship that allows the platform AWS account to assume this role, enabling the platform AWS account to distribute AMIs.

See https://docs.aws.amazon.com/imagebuilder/latest/userguide/cross-account-dist.html for an explanation of why this is required.

This PR follows https://github.com/wellcomecollection/platform-infrastructure/pull/416

## How to test

- [x] Attempt to distribute an AMI to the workflow account, can it be used by an EC2 instance in that account?

## How can we measure success?

AMIs built in the platform account can be used in other accounts.