### PR TITLE
Create a GitHub OIDC provider & assumable role for GitHub actions

### DIFF
--- a/accounts/digirati/.terraform.lock.hcl
+++ b/accounts/digirati/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.12.0"
+  version = "5.36.0"
   hashes = [
-    "h1:GWmoet1icv68bVcTQ4EGOCUUJ5vbyhzubL8Y3c7Se+Q=",
+    "h1:54QgAU2vY65WZsiZ9FligQfIf7hQUvwse4ezMwVMwgg=",
+    "zh:0da8409db879b2c400a7d9ed1311ba6d9eb1374ea08779eaf0c5ad0af00ac558",
+    "zh:1b7521567e1602bfff029f88ccd2a182cdf97861c9671478660866472c3333fa",
+    "zh:1cab4e6f3a1d008d01df44a52132a90141389e77dbb4ec4f6ac1119333242ecf",
+    "zh:1df9f73595594ce8293fb21287bcacf5583ae82b9f3a8e5d704109b8cf691646",
+    "zh:2b5909268db44b6be95ff6f9dc80d5f87ca8f63ba530fe66723c5fdeb17695fc",
+    "zh:37dd731eeb0bc1b20e3ec3a0cb5eb7a730edab425058ff40f2243438acc82830",
+    "zh:3e94c76a2b607a1174d10f5712aed16cb32216ac1c91bd6f21749d61a14045ac",
+    "zh:40e6ba3184d2d3bf283a07feed8b79c1bbc537a91215cac7b3521b9ccb3e503e",
+    "zh:67e52353fea47eb97825f6eb6fddd1935e0ff3b53a8861d23a70c2babf83ae51",
+    "zh:6d2e2f390e0c7b2cd2344b1d5d6eec8a1c11cf35d19f1d6f341286f2449e9e10",
+    "zh:7005483c43926800fad5bb18e27be883dac4339edb83a8f18ccdc7edf86fafc2",
+    "zh:7073fa7ccaa9b07c2cf7b24550a90e11f4880afd5c53afd51278eff0154692a0",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6d48620e526c766faec9aeb20c40a98c1810c69b6699168d725f721dfe44846",
+    "zh:e29b651b5f39324656f466cd24a54861795cc423a1b58372f4e1d2d2112d10a0",
   ]
 }

--- a/accounts/platform/.terraform.lock.hcl
+++ b/accounts/platform/.terraform.lock.hcl
@@ -2,8 +2,42 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.12.0"
+  version = "5.41.0"
   hashes = [
-    "h1:GWmoet1icv68bVcTQ4EGOCUUJ5vbyhzubL8Y3c7Se+Q=",
+    "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
+    "zh:0553331a6287c146353b6daf6f71987d8c000f407b5e29d6e004ea88faec2e67",
+    "zh:1a11118984bb2950e8ee7ef17b0f91fc9eb4a42c8e7a9cafd7eb4aca771d06e4",
+    "zh:236fedd266d152a8233a7fe27ffdd99ca27d9e66a9618a988a4c3da1ac24a33f",
+    "zh:34bc482ea04cf30d4d216afa55eecf66854e1acf93892cb28a6b5af91d43c9b7",
+    "zh:39d7eb15832fe339bf46e3bab9852280762a1817bf1afc459eecd430e20e3ad5",
+    "zh:39fb07429c51556b05170ec2b6bd55e2487adfe1606761eaf1f2a43c4bb20e47",
+    "zh:71d7cd3013e2f3fa0f65194af29ee6f5fa905e0df2b72b723761dc953f4512ea",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b271ae12394e7e2ce6da568b42226a146e90fd705e02a670fcb93618c4aa19f",
+    "zh:a884dd978859d001709681f9513ba0fbb0753d1d459a7f3434ecc5f1b8699c49",
+    "zh:b8c3c7dc10ae4f6143168042dcf8dee63527b103cc37abc238ea06150af38b6e",
+    "zh:ba94ffe0893ad60c0b70c402e163b4df2cf417e93474a9cc1a37535bba18f22d",
+    "zh:d5ba851d971ff8d796afd9a100acf55eaac0c197c6ab779787797ce66f419f0e",
+    "zh:e8c090d0c4f730c4a610dc4f0c22b177a0376d6f78679fc3f1d557b469e656f4",
+    "zh:ed7623acde26834672969dcb5befdb62900d9f216d32e7478a095d2b040a0ea7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.5"
+  hashes = [
+    "h1:zeG5RmggBZW/8JWIVrdaeSJa0OG62uFX5HY1eE8SjzY=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/accounts/platform/github_oidc.tf
+++ b/accounts/platform/github_oidc.tf
@@ -18,8 +18,8 @@ locals {
 
 // The repositories that are allowed to assume the github_actions_assume_role
 variable "github_repositories" {
-    type    = list(string)
-    default = [
+  type = list(string)
+  default = [
     "wellcomecollection/catalogue-api",
   ]
 }
@@ -33,9 +33,9 @@ resource "aws_iam_openid_connect_provider" "github" {
   ]
 
   thumbprint_list = concat(
-      local.github_oidc_thumbprints,
-      [data.tls_certificate.github.certificates[0].sha1_fingerprint],
-    )
+    local.github_oidc_thumbprints,
+    [data.tls_certificate.github.certificates[0].sha1_fingerprint],
+  )
 
   url = "https://token.actions.githubusercontent.com"
 }

--- a/accounts/platform/github_oidc.tf
+++ b/accounts/platform/github_oidc.tf
@@ -1,0 +1,93 @@
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+locals {
+  // These values are published by GitHub and are used to verify the OIDC provider:
+  // https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+  // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html 
+  github_oidc_thumbprints = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+
+  github_repositories = [
+    "wellcomecollection/catalogue-api",
+  ]
+}
+
+// The repositories that are allowed to assume the github_actions_assume_role
+variable "github_repositories" {
+    type    = list(string)
+    default = [
+    "wellcomecollection/catalogue-api",
+  ]
+}
+
+// This is used to provide federated access to the AWS account for GitHub Actions
+// See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+
+resource "aws_iam_openid_connect_provider" "github" {
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = concat(
+      local.github_oidc_thumbprints,
+      [data.tls_certificate.github.certificates[0].sha1_fingerprint],
+    )
+
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test = "StringLike"
+      values = [
+        for repo in var.github_repositories :
+        "repo:%{if length(regexall(":+", repo)) > 0}${repo}%{else}${repo}:*%{endif}"
+      ]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+      type        = "Federated"
+    }
+  }
+
+  version = "2012-10-17"
+}
+
+resource "aws_iam_role" "github_actions" {
+  name_prefix          = "github-actions-"
+  description          = "Inital role assumed by the GitHub OIDC provider"
+  max_session_duration = 3600 // Minimum session duration in seconds, 1 hour
+  assume_role_policy   = data.aws_iam_policy_document.github_actions_assume_role.json
+
+  depends_on = [aws_iam_openid_connect_provider.github]
+}
+
+// We allow the GitHub Actions role to assume the appropriate role to perform build actions
+data "aws_iam_policy_document" "github_actions_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    resources = [
+      aws_iam_role.s3_scala_releases_read.arn
+    ]
+  }
+}
+
+output "github_actions_assume_role_arn" {
+  value = aws_iam_role.github_actions.arn
+}


### PR DESCRIPTION
## What does this change?

This change creates a GitHub OIDC provider to allow GitHub actions federated access to AWS without creating IAM credentials. 

See https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/

This change allows GitHub actions that meet specified conditions to perform changes in AWS in a similar way to our Buildkite CI setup. Following https://github.com/wellcomecollection/catalogue-api/pull/763, and fixes the [resulting build errors](https://github.com/wellcomecollection/catalogue-api/actions/runs/8330581509/job/22795559143).

Permission to assume the `github_actions` role is restricted currently to actions running in catalogue-api repository. See https://github.com/wellcomecollection/catalogue-api/pull/766 for the change to use the role provisioned here.

> [!NOTE]
> This change is applied.

## How to test

- [x] Can we [successfully assume this role](https://github.com/wellcomecollection/catalogue-api/actions/runs/8345452729/job/22840390420) and use its permissions?

## How can we measure success?

Consumers of this role are able to perform CI tasks previously only available to Buildkite runners. Specifically this allows us to run the `scalacenter/sbt-dependency-submission` GitHub action which reports the Scala dependency graph to GitHub allowing us to understand any vulnerabilities..

## Have we considered potential risks?

Here we are allowing GitHub actions to perform changes in AWS, and in doing so extend trust to GitHub not to misuse this access. In addition this expands the permissions of anyone able to run the GitHub action or submit change to the select repositories to include those of the assumable roles.

It's very unlikely GitHub will be compromised in a way that makes the OIDC relationship risky & in addition the changes here only allow assuming a role with S3 read access to a named bucket and path.

