### PR TITLE
Add concepts pipeline repo permissions for GHA

### DIFF
--- a/accounts/platform/github_oidc.tf
+++ b/accounts/platform/github_oidc.tf
@@ -23,6 +23,7 @@ variable "github_repositories" {
     "wellcomecollection/catalogue-api",
     "wellcomecollection/catalogue-pipeline",
     "wellcomecollection/storage-service",
+    "wellcomecollection/concepts-pipeline",
   ]
 }
 


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/aws-account-infrastructure/pull/19, https://github.com/wellcomecollection/concepts-pipeline/pull/134 allowing 1 more Scala repositories actions to pull their dependencies from S3 in order report their dependency graph to GitHub.

### `terraform plan`
```
Terraform will perform the following actions:

  # aws_iam_role.github_actions will be updated in-place
  ~ resource "aws_iam_role" "github_actions" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike   = {
                              ~ "token.actions.githubusercontent.com:sub" = [
                                    # (2 unchanged elements hidden)
                                    "repo:wellcomecollection/storage-service:*",
                                  + "repo:wellcomecollection/concepts-pipeline:*",
                                ]
                            }
                            # (1 unchanged attribute hidden)
                        }
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "<redacted>"
        name                  = "<redacted>"
        tags                  = {}
        # (10 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## How to test

- [ ] Apply this change, do the PRs that depend on it work after merging?

## How can we measure success?

Enables other work to improve visibility and reduction of vulnerabilities.

## Have we considered potential risks?

This change should help manage / reduce risk.