### PR TITLE
Extend experience-ci permissions to read CivicUK secret

### DIFF
--- a/accounts/experience/.terraform.lock.hcl
+++ b/accounts/experience/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.12.0"
+  version = "5.52.0"
   hashes = [
-    "h1:GWmoet1icv68bVcTQ4EGOCUUJ5vbyhzubL8Y3c7Se+Q=",
+    "h1:ucZxfJtHMHBp4Amnk0K3Bdr7Umbk6he8byey/+u41Lc=",
+    "zh:22c4599d47cd59e5519c52afc528fa2aec43b4434f369870ee2806daa071449d",
+    "zh:3c2edc482662a654f84db4cd3f2cdd8f200147207d053d2e95082744b7814e6d",
+    "zh:57edc36f908c64de37e92a978f3d675604315a725268da936fcd1e270199db47",
+    "zh:79e7afd5fb161f2eb2b7f8e7fd5cbb7f56a2c64f141b56f511ec69337ad3e96b",
+    "zh:82c6ae9a7f971b6ee8c476b6eb7f1be9d24ddd183cbf025f52628084ddb3a5ae",
+    "zh:92faecc0a8f573f57f37d24415862380a40341eb13d66beb738dd0873899a58e",
+    "zh:963d3c0e1aa22c872cd96f04ceb41c388137b972f714efbde989221bf7f6f723",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:af6d3bb94aa8a84d740e3731d2379cc5e12aa48d5db0f7489c4639f3814a22d7",
+    "zh:b9f7aceeaf5daf71394eab9bf0f9f56fdc762cac90e4d62e63aa3fcdf6c1c127",
+    "zh:c3dcfc2569edae4f36b798c76da7f7633e7bf322505d447d7c370a56c2a30dd2",
+    "zh:c8abb21c5ceba857f0eaff9e531d781dc655f8cdfae1cf056066daae72546a7f",
+    "zh:d92004a6a2a770d2542fd9c01b685418ab8d7ab422cf2cdce35dde789bc8593c",
+    "zh:dc794660b1d6d8f26a917e0ffab1875aa75144736875efaa60f29c72bf02afbf",
+    "zh:df931c4905e35ae43d558f6cda15f05710a7a24ecbb94533f8822e7572126512",
   ]
 }

--- a/accounts/experience/iam_experience_ci.tf
+++ b/accounts/experience/iam_experience_ci.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "experience_ci" {
       "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:builds/*",
     ]
   }
-  
+
   statement {
     sid = "GetWebAppSecrets"
 

--- a/accounts/experience/iam_experience_ci.tf
+++ b/accounts/experience/iam_experience_ci.tf
@@ -54,6 +54,18 @@ data "aws_iam_policy_document" "experience_ci" {
       "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:builds/*",
     ]
   }
+  
+  statement {
+    sid = "GetWebAppSecrets"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:civicuk/api_key",
+    ]
+  }
 
   statement {
     sid = "GetApiSecrets"


### PR DESCRIPTION
## What does this change?

This change allows the experience-ci role used to build the experience webapps access to read the civicuk api key from secrets manager so that it can be used at buildtime.

See https://github.com/wellcomecollection/wellcomecollection.org/pull/10905 for more context.

## How to test

- [ ] [This PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/10905) should build cleanly.

## How can we measure success?

The content webapp can build and run without error, while keeping fixed API keys out of our codebase.

## Have we considered potential risks?

This change extends permissions of the experience-ci role, but it is limited to a single secret so risk is minimised.
