### PR TITLE
Add permissions to get prismic-model secrets

### DIFF
--- a/accounts/experience/iam_experience_buildkite.tf
+++ b/accounts/experience/iam_experience_buildkite.tf
@@ -44,6 +44,18 @@ data "aws_iam_policy_document" "experience_ci" {
   }
 
   statement {
+    sid = "GetPrismicSecrets"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:prismic-model/*",
+    ]
+  }
+
+  statement {
     sid = "GetBuildSecrets"
 
     actions = [


### PR DESCRIPTION
## What does this change?

Adds `prismic-model/*` as permitted secrets to access. We do not know how this has been working as it wasn't there. Our current theory is that it had been done manually and experience's setup having been deployed last week overwrote it. The relevant token was marked as last fetched in October 2022, so we are at a bit of a loss. 

## How to test

The scripts run and succeed https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/14249#_

## How can we measure success?

See above!

## Have we considered potential risks?

We don't understand why it wasn't there in the first place, so it was riskier not to have it.

