### PR TITLE
Create policies for initial roles

### DIFF
--- a/modules/initial_role/main.tf
+++ b/modules/initial_role/main.tf
@@ -41,6 +41,11 @@ resource "aws_iam_role_policy" "allow_assume_roles" {
   policy = data.aws_iam_policy_document.allow_assume_all_assumable_roles.json
 }
 
+resource "aws_iam_policy" "policy" {
+  name        = var.name
+  policy = data.aws_iam_policy_document.allow_assume_all_assumable_roles.json
+}
+
 data "aws_iam_policy_document" "allow_assume_all_assumable_roles" {
   statement {
     effect = "Allow"

--- a/modules/initial_role/main.tf
+++ b/modules/initial_role/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy" "allow_assume_roles" {
 }
 
 resource "aws_iam_policy" "policy" {
-  name        = var.name
+  name   = var.name
   policy = data.aws_iam_policy_document.allow_assume_all_assumable_roles.json
 }
 


### PR DESCRIPTION
## What does this change?

This change creates named policies for the initial roles in order to reference these policies as "customer manager policies" in IAM Identity center. This allows us to reference these policies in IAM Identity Center configuration allowing Collection devs access with the same permissions they have now.

## How to test

 - [ ] Apply this change, can it be referred to in Identity Center?

## How can we measure success?

The initial role policies described in this repository are kept in sync with those referenced in Identity Center, removing the need to duplicate an inline policy.

## Have we considered potential risks?

This change should not increase permissions of existing users.
