### PR TITLE
Add premissions for storage gha to update daily reporter lambda

### DIFF
--- a/accounts/storage/iam_storage_gha.tf
+++ b/accounts/storage/iam_storage_gha.tf
@@ -39,7 +39,8 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy" {
       "lambda:UpdateFunctionCode"
     ]
     resources = [
-      "arn:aws:lambda:eu-west-1:975596993436:function:ingest_inspector_backend"
+      "arn:aws:lambda:eu-west-1:975596993436:function:ingest_inspector_backend",
+      "arn:aws:lambda:eu-west-1:975596993436:function:daily_reporter"
     ]
   }
 }


### PR DESCRIPTION
## What does this change?

This change adds permissions for the storage service github action role to deploy the daily reporter lambda following: https://github.com/wellcomecollection/storage-service/pull/1136

## How to test

- [ ] Re-run the workflow, does it pass: https://github.com/wellcomecollection/storage-service/actions/runs/10401523198?

## How can we measure success?

Deployments of the daily reporter lambda can proceed without issue.

## Have we considered potential risks?

This slightly expands the permissions of the role for this GitHub action, but the added permissions are tightly scoped.
