### PR TITLE
Terraform scala formatting permissions

### DIFF
--- a/accounts/platform/gha_org_secrets.tf
+++ b/accounts/platform/gha_org_secrets.tf
@@ -27,8 +27,8 @@ data "github_repository" "scala-libs" {
 
 // secret value for role arn allowing access to formatting resources, eg. images, S3
 resource "github_actions_organization_secret" "gha_scala_formatting_role_arn" {
-  secret_name             = "GHA_SCALA_FORMATTING_ROLE_ARN"
-  visibility              = "selected"
+  secret_name = "GHA_SCALA_FORMATTING_ROLE_ARN"
+  visibility  = "selected"
   selected_repository_ids = [
     data.github_repository.catalogue-api.repo_id,
     data.github_repository.catalogue-pipeline.repo_id,
@@ -36,5 +36,5 @@ resource "github_actions_organization_secret" "gha_scala_formatting_role_arn" {
     data.github_repository.storage-service.repo_id,
     data.github_repository.scala-libs.repo_id
   ]
-  plaintext_value         = module.gha_scala_formatting_role.role_arn
+  plaintext_value = module.gha_scala_formatting_role.role_arn
 }

--- a/accounts/platform/gha_org_secrets.tf
+++ b/accounts/platform/gha_org_secrets.tf
@@ -10,12 +10,31 @@ terraform {
 data "github_repository" "catalogue-api" {
   full_name = "wellcomecollection/catalogue-api"
 }
+data "github_repository" "catalogue-pipeline" {
+  full_name = "wellcomecollection/catalogue-pipeline"
+}
+data "github_repository" "concepts-pipeline" {
+  full_name = "wellcomecollection/concepts-pipeline"
+}
+data "github_repository" "storage-service" {
+  full_name = "wellcomecollection/storage-service"
+}
+data "github_repository" "scala-libs" {
+  full_name = "wellcomecollection/scala-libs"
+}
+
 // creates a gha secret at the org level
 
 // secret value for role-to-assume in workflows that need to pull from ecr
 resource "github_actions_organization_secret" "gha_scala_formatting_role_arn" {
   secret_name             = "GHA_SCALA_FORMATTING_ROLE_ARN"
   visibility              = "selected"
-  selected_repository_ids = [data.github_repository.catalogue-api.repo_id]
+  selected_repository_ids = [
+    data.github_repository.catalogue-api.repo_id,
+    data.github_repository.catalogue-pipeline.repo_id,
+    data.github_repository.concepts-pipeline.repo_id,
+    data.github_repository.storage-service.repo_id,
+    data.github_repository.scala-libs.repo_id
+  ]
   plaintext_value         = module.gha_scala_formatting_role.role_arn
 }

--- a/accounts/platform/gha_org_secrets.tf
+++ b/accounts/platform/gha_org_secrets.tf
@@ -25,7 +25,7 @@ data "github_repository" "scala-libs" {
 
 // creates a gha secret at the org level
 
-// secret value for role-to-assume in workflows that need to pull from ecr
+// secret value for role arn allowing access to formatting resources, eg. images, S3
 resource "github_actions_organization_secret" "gha_scala_formatting_role_arn" {
   secret_name             = "GHA_SCALA_FORMATTING_ROLE_ARN"
   visibility              = "selected"

--- a/accounts/platform/github_oidc.tf
+++ b/accounts/platform/github_oidc.tf
@@ -30,6 +30,10 @@ module "gha_scala_formatting_role" {
   policy_document = data.aws_iam_policy_document.gha_scala_formatting.json
   github_repositories = [
     "wellcomecollection/catalogue-api",
+    "wellcomecollection/catalogue-pipeline",
+    "wellcomecollection/concepts-pipeline",
+    "wellcomecollection/storage-service",
+    "wellcomecollection/scala-libs",
   ]
   role_name                = "scala_formatting"
   github_oidc_provider_arn = module.aws_account.openid_connect_provider_arn


### PR DESCRIPTION
APPLIED 2024-09-02

## What does this change?

Adds the other repositories that will use [scala_formatting](https://github.com/wellcomecollection/.github/blob/main/.github/workflows/scala_formatting.yml) workflow
They each needs to be able to `AssumeRoleWithWebIdentity` for the `gha_scala_formatting_role` whose GHA secret arn they also need to be allowed to read

## How to test

When the new formatting workflow is added to a branch in any of these repos, it should not run into permission issues

## How can we measure success?

[scala_formatting](https://github.com/wellcomecollection/.github/blob/main/.github/workflows/scala_formatting.yml) can run successfully on the added repos

## Have we considered potential risks?

This has been tested in [catalogue-api](https://github.com/wellcomecollection/catalogue-api/pull/804/files)
It runs on feature branches so we can test and validate without affecting the main branch or production systems.

### `terraform plan` output
```
Terraform will perform the following actions:

  # github_actions_organization_secret.gha_scala_formatting_role_arn will be created
  + resource "github_actions_organization_secret" "gha_scala_formatting_role_arn" {
      + created_at              = (known after apply)
      + id                      = (known after apply)
      + plaintext_value         = (sensitive value)
      + secret_name             = "GHA_SCALA_FORMATTING_ROLE_ARN"
      + selected_repository_ids = [
          + 162274705,
          + 162326863,
          + 271297399,
          + 360881946,
          + 511496444,
        ]
      + updated_at              = (known after apply)
      + visibility              = "selected"
    }

  # module.gha_scala_formatting_role.aws_iam_role.github_actions will be updated in-place
  ~ resource "aws_iam_role" "github_actions" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike   = {
                              ~ "token.actions.githubusercontent.com:sub" = "repo:wellcomecollection/catalogue-api:*" -> [
                                  + "repo:wellcomecollection/catalogue-api:*",
                                  + "repo:wellcomecollection/catalogue-pipeline:*",
                                  + "repo:wellcomecollection/concepts-pipeline:*",
                                  + "repo:wellcomecollection/storage-service:*",
                                  + "repo:wellcomecollection/scala-libs:*",
                                ]
                            }
                            # (1 unchanged attribute hidden)
                        }
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "gha-scala_formatting-20240828082109325200000001"
        name                  = "gha-scala_formatting-20240828082109325200000001"
        tags                  = {}
        # (11 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```
